### PR TITLE
Remove `Fetcher.ts` from `.fernignore`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -3,7 +3,6 @@
 README.md
 CITATIONS.md
 LICENSE
-src/core/fetcher/Fetcher.ts
 src/wrapper/
 src/index.ts
 tsconfig.json


### PR DESCRIPTION
This PR removes `Fetcher.ts` from the `.fernignore` file because the generator now supports using fetch directly. 