### PR TITLE
🌿 reorganize streaming client

### DIFF
--- a/src/wrapper/HumeStreamingClient.ts
+++ b/src/wrapper/HumeStreamingClient.ts
@@ -1,12 +1,11 @@
 import * as Hume from "../api";
-import * as core from "../core";
 import * as serializers from "../serialization";
 import { StreamSocket } from "./StreamSocket";
 import WebSocket from "ws";
 
 export declare namespace HumeStreamingClient {
     interface Options {
-        apiKey: core.Supplier<string>;
+        apiKey: string;
         /* Defaults to 10 seconds */
         openTimeoutInSeconds?: number;
     }
@@ -18,95 +17,96 @@ export declare namespace HumeStreamingClient {
             aggregating media across streaming payloads within one WebSocket connection. */
         streamWindowMs?: number;
 
-        onOpen?: () => void;
+        onOpen?: (event: WebSocket.Event) => void;
         onMessage?: (message: Hume.ModelResponse) => void;
         onWarning?: (error: Hume.ModelsWarning) => void;
         onError?: (error: Hume.ModelsError) => void;
-        onClose?: () => void;
+        onClose?: (event: WebSocket.Event) => void;
     }
 }
 
 export class HumeStreamingClient {
     constructor(protected readonly _options: HumeStreamingClient.Options) {}
 
-    public async connect(
-        args: HumeStreamingClient.ConnectArgs
-    ): Promise<StreamSocket> {
+    public connect(args: HumeStreamingClient.ConnectArgs): StreamSocket {
         const websocket = new WebSocket(`wss://api.hume.ai/v0/stream/models`, {
             headers: {
-                "X-Hume-Api-Key": await core.Supplier.get(this._options.apiKey),
+                "X-Hume-Api-Key": this._options.apiKey,
             },
             timeout: this._options.openTimeoutInSeconds,
         });
-        websocket.addEventListener("open", () => {
-            args.onOpen?.();
+
+        websocket.addEventListener("open", (event) => {
+            args.onOpen?.(event);
         });
+
         websocket.addEventListener("error", (e) => {
             args.onError?.({
                 code: e.type,
                 error: e.message,
             });
         });
+
         websocket.addEventListener("message", async ({ data }) => {
-            const body = JSON.parse(data as string);
-
-            const parsedResponse = await serializers.ModelResponse.parse(body, {
-                unrecognizedObjectKeys: "passthrough",
-                allowUnrecognizedUnionMembers: true,
-                allowUnrecognizedEnumValues: true,
-                breadcrumbsPrefix: ["response"],
+            parse(data, {
+                onMessage: args.onMessage,
+                onWarning: args.onWarning,
+                onError: args.onError,
             });
-            if (parsedResponse.ok) {
-                args.onMessage?.(parsedResponse.value);
-                return;
-            }
-
-            const parsedWarning = await serializers.ModelsWarning.parse(body, {
-                unrecognizedObjectKeys: "passthrough",
-                allowUnrecognizedUnionMembers: true,
-                allowUnrecognizedEnumValues: true,
-                breadcrumbsPrefix: ["response"],
-            });
-            if (parsedWarning.ok) {
-                args.onWarning?.(parsedWarning.value);
-                return;
-            }
-
-            const parsedError = await serializers.ModelsError.parse(body, {
-                unrecognizedObjectKeys: "passthrough",
-                allowUnrecognizedUnionMembers: true,
-                allowUnrecognizedEnumValues: true,
-                breadcrumbsPrefix: ["response"],
-            });
-            if (parsedError.ok) {
-                args.onError?.(parsedError.value);
-                return;
-            }
-        });
-        websocket.addEventListener("close", () => {
-            args.onClose?.();
         });
 
-        return new Promise((resolve) => {
-            if (websocket && websocket.readyState !== websocket.OPEN) {
-                websocket.addEventListener("open", () => {
-                    resolve(
-                        new StreamSocket({
-                            websocket,
-                            streamWindowMs: args.streamWindowMs,
-                            config: args.config,
-                        })
-                    );
-                });
-            } else {
-                resolve(
-                    new StreamSocket({
-                        websocket,
-                        streamWindowMs: args.streamWindowMs,
-                        config: args.config,
-                    })
-                );
-            }
+        websocket.addEventListener("close", (event) => {
+            args.onClose?.(event);
         });
+
+        return new StreamSocket({
+            websocket,
+            streamWindowMs: args.streamWindowMs,
+            config: args.config,
+        });
+    }
+}
+
+export async function parse(
+    data: WebSocket.Data,
+    args: {
+        onMessage?: (message: Hume.ModelResponse) => void;
+        onWarning?: (error: Hume.ModelsWarning) => void;
+        onError?: (error: Hume.ModelsError) => void;
+    } = {}
+): Promise<Hume.ModelResponse | Hume.ModelsWarning | Hume.ModelsError | undefined> {
+    const message = JSON.parse(data as string);
+
+    const parsedResponse = await serializers.ModelResponse.parse(message, {
+        unrecognizedObjectKeys: "passthrough",
+        allowUnrecognizedUnionMembers: true,
+        allowUnrecognizedEnumValues: true,
+        breadcrumbsPrefix: ["response"],
+    });
+    if (parsedResponse.ok) {
+        args.onMessage?.(parsedResponse.value);
+        return parsedResponse.value;
+    }
+
+    const parsedWarning = await serializers.ModelsWarning.parse(message, {
+        unrecognizedObjectKeys: "passthrough",
+        allowUnrecognizedUnionMembers: true,
+        allowUnrecognizedEnumValues: true,
+        breadcrumbsPrefix: ["response"],
+    });
+    if (parsedWarning.ok) {
+        args.onWarning?.(parsedWarning.value);
+        return parsedWarning.value;
+    }
+
+    const parsedError = await serializers.ModelsError.parse(message, {
+        unrecognizedObjectKeys: "passthrough",
+        allowUnrecognizedUnionMembers: true,
+        allowUnrecognizedEnumValues: true,
+        breadcrumbsPrefix: ["response"],
+    });
+    if (parsedError.ok) {
+        args.onError?.(parsedError.value);
+        return parsedError.value;
     }
 }

--- a/src/wrapper/base64Encode.ts
+++ b/src/wrapper/base64Encode.ts
@@ -1,0 +1,12 @@
+export function base64Encode(str: string): string {
+    if (typeof btoa === "function") {
+        // Browser environment
+        return btoa(str);
+    } else if (typeof Buffer === "function") {
+        // Node.js environment
+        const buffer = Buffer.from(str, "utf-8");
+        return buffer.toString("base64");
+    } else {
+        throw new Error("Base64 encoding not supported in this environment.");
+    }
+}


### PR DESCRIPTION
This PR pushes a couple of quality-of-life updates to the streaming client: 
- no more async connect, just connect directly
- users can pas in `onOpen`, `onError`, `onWarning`, `onMessage` and `onClose`
- users can await responses directly