### PR TITLE
updates sendAudioInput method, removes sendRaw private function

### DIFF
--- a/src/api/resources/empathicVoice/client/StreamSocket.ts
+++ b/src/api/resources/empathicVoice/client/StreamSocket.ts
@@ -16,9 +16,12 @@ export class StreamSocket {
 
     /**
      * Send audio input
-     **/
-    public async sendAudioInput(message: string | ArrayBuffer | Blob | ArrayBufferView): Promise<void> {
-        await this.sendRaw(message);
+     */
+    public async sendAudioInput(message: Omit<Hume.empathicVoice.AudioInput, "type">): Promise<void> {
+        await this.sendJson({
+            type: "audio_input",
+            ...message,
+        });
     }
 
     /**
@@ -36,8 +39,8 @@ export class StreamSocket {
      */
     public async sendAssistantInput(message: Omit<Hume.empathicVoice.AssistantInput, "type">): Promise<void> {
         await this.sendJson({
+            type: "assistant_input",
             ...message,
-            type: "assistant_input"
         });
     }
 
@@ -64,11 +67,6 @@ export class StreamSocket {
             unrecognizedObjectKeys: "strip",
         });
         this.websocket.send(JSON.stringify(jsonPayload));
-    }
-
-    private async sendRaw(payload: any): Promise<void> {
-        await this.tillSocketOpen();
-        this.websocket.send(payload);
     }
 
     private async tillSocketOpen(): Promise<WebSocket> {


### PR DESCRIPTION
## Summary

- Updates the `sendAudioInput` method to accept the `audio_input` message JSON, omitting the `type` field. (to be consistent with the other publish methods.)
- Removes the `sendRaw` private method, to promote use of the standardized input interface when sending audio.