### PR TITLE
Zg/add chat resumability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hume",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "private": false,
     "repository": "https://github.com/HumeAI/hume-typescript-sdk",
     "main": "./index.js",

--- a/src/api/resources/empathicVoice/client/StreamSocket.ts
+++ b/src/api/resources/empathicVoice/client/StreamSocket.ts
@@ -35,11 +35,31 @@ export class StreamSocket {
     }
 
     /**
-     * Send session settings
+     * Send assistant input
      */
     public async sendAssistantInput(message: Omit<Hume.empathicVoice.AssistantInput, "type">): Promise<void> {
         await this.sendJson({
             type: "assistant_input",
+            ...message,
+        });
+    }
+
+    /**
+     * Send pause assistant message
+     */
+    public async pauseAssistant(message: Omit<Hume.empathicVoice.PauseAssistantMessage, "type">): Promise<void> {
+        await this.sendJson({
+            type: "pause_assistant_message",
+            ...message,
+        });
+    }
+
+    /**
+     * Send resume assistant message
+     */
+    public async resumeAssistant(message: Omit<Hume.empathicVoice.ResumeAssistantMessage, "type">): Promise<void> {
+        await this.sendJson({
+            type: "resume_assistant_message",
             ...message,
         });
     }

--- a/src/wrapper/empathicVoice/chat/ChatClient.ts
+++ b/src/wrapper/empathicVoice/chat/ChatClient.ts
@@ -18,6 +18,9 @@ export declare namespace ChatClient {
         /** The version of the configuration. */
         configVersion?: string;
 
+        /** The ID of a chat group, used to resume a previous chat. */
+        resumedChatGroupId?: string;
+
         onOpen?: () => void;
         onMessage?: (message: Hume.empathicVoice.SubscribeEvent) => void;
         onError?: (error: Hume.empathicVoice.WebSocketError) => void;
@@ -38,6 +41,9 @@ export class ChatClient {
         }
         if (args.configVersion != null) {
             queryParams["config_version"] = args.configVersion;
+        }
+        if (args.resumedChatGroupId != null) {
+            queryParams["resumed_chat_group_id"] = args.resumedChatGroupId;
         }
 
         const websocket = await core.connect(`wss://api.hume.ai/v0/evi/chat?${qs.stringify(queryParams)}`);


### PR DESCRIPTION
## Summary

- Adds `pauseAssistant` and `resumeAssistant` methods to `StreamSocket`
- Adds `resumedChatGroupId` to `ConnectArgs` interface and logic to add the `resumed_chat_group_id` query param to the EVI handshake request when provided.