### PR TITLE
Zg/add missing send methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hume",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "private": false,
     "repository": "https://github.com/HumeAI/hume-typescript-sdk",
     "main": "./index.js",

--- a/src/api/resources/empathicVoice/client/StreamSocket.ts
+++ b/src/api/resources/empathicVoice/client/StreamSocket.ts
@@ -65,6 +65,26 @@ export class StreamSocket {
     }
 
     /**
+     * Send tool response message
+     */
+    public async sendToolResponseMessage(message: Omit<Hume.empathicVoice.ToolResponseMessage, "type">): Promise<void> {
+        await this.sendJson({
+            type: "tool_response",
+            ...message,
+        });
+    }
+
+    /**
+     * Send tool error message
+     */
+    public async sendToolErrorMessage(message: Omit<Hume.empathicVoice.ToolErrorMessage, "type">): Promise<void> {
+        await this.sendJson({
+            type: "tool_error",
+            ...message,
+        });
+    }
+
+    /**
      * Send text input
      */
     public async sendTextInput(text: string): Promise<void> {


### PR DESCRIPTION
## Summary
Although the types were generated, the following methods were not generated on the `StreamSocket` class:

- `sendToolResponseMessage`
- `sendToolErrorMessage`

Methods have been manually added to the class.