### PR TITLE
(feat): export `Chat.ConnectArgs` and `ChatSocket`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hume",
-    "version": "0.8.1-beta0",
+    "version": "0.8.1-beta1",
     "private": false,
     "repository": "https://github.com/HumeAI/hume-typescript-sdk",
     "main": "./index.js",

--- a/src/api/resources/empathicVoice/resources/chat/client/index.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/index.ts
@@ -1,0 +1,2 @@
+export { ChatSocket } from "./Socket";
+export { Chat } from "./Client";


### PR DESCRIPTION
While these classes and types are accessible from the top level `Hume` client, they will now be accessible from the top level of the SDK. 