### PR TITLE
(feat): init via token

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -12,6 +12,7 @@ src/wrapper
 src/index.ts
 
 # EVI WebSocket
+src/Client.ts
 src/api/resources/empathicVoice/client/Client.ts
 src/api/resources/empathicVoice/resources/chat/index.ts
 src/api/resources/empathicVoice/resources/chat/client

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hume",
-    "version": "0.8.1-beta7",
+    "version": "0.8.1-beta8",
     "private": false,
     "repository": "https://github.com/HumeAI/hume-typescript-sdk",
     "main": "./index.js",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -11,6 +11,7 @@ export declare namespace HumeClient {
     interface Options {
         environment?: core.Supplier<environments.HumeEnvironment | string>;
         apiKey?: core.Supplier<string | undefined>;
+        accessToken?: core.Supplier<string | undefined>;
         fetcher?: core.FetchFunction;
     }
 

--- a/src/api/resources/empathicVoice/client/Client.ts
+++ b/src/api/resources/empathicVoice/client/Client.ts
@@ -15,6 +15,7 @@ export declare namespace EmpathicVoice {
     interface Options {
         environment?: core.Supplier<environments.HumeEnvironment | string>;
         apiKey?: core.Supplier<string | undefined>;
+        accessToken?: core.Supplier<string | undefined>;
         fetcher?: core.FetchFunction;
     }
 


### PR DESCRIPTION
In this PR, the `HumeClient` now supports being initialized with an `accessToken`. 