### PR TITLE
(feat): export `tillSocketOpen` on ChatSocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hume",
-    "version": "0.8.1-beta8",
+    "version": "0.8.1-beta9",
     "private": false,
     "repository": "https://github.com/HumeAI/hume-typescript-sdk",
     "main": "./index.js",

--- a/src/api/resources/empathicVoice/resources/chat/client/Client.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Client.ts
@@ -36,9 +36,9 @@ export class Chat {
         const queryParams: Record<string, string | string[] | object | object[]> = {};
 
         if (this._options.accessToken != null) {
-            queryParams["accessToken"] = core.Supplier.get(this._options.accessToken);
+            queryParams["accessToken"] = this._options.accessToken;
         } else if (this._options.apiKey != null) {
-            queryParams["apiKey"] = core.Supplier.get(this._options.apiKey);
+            queryParams["apiKey"] = this._options.apiKey;
         }
         if (args.configId != null) {
             queryParams["config_id"] = args.configId;
@@ -57,9 +57,8 @@ export class Chat {
         }
 
         const socket = new core.ReconnectingWebSocket(`wss://api.hume.ai/v0/evi/chat?${qs.stringify(queryParams)}`, [], {
-            startClosed: true,
             debug: args.debug ?? false,
-            maxRetries: args.reconnectAttempts, 
+            maxRetries: args.reconnectAttempts ?? 30, 
         });
 
         return new ChatSocket({

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -1,10 +1,8 @@
 import * as Events from './events';
+import { WebSocket as NodeWebSocket } from 'ws';
 
 const getGlobalWebSocket = (): WebSocket | undefined => {
-    if (typeof WebSocket !== 'undefined') {
-        // @ts-ignore
-        return WebSocket;
-    }
+    return (global as any).WebSocket ??= NodeWebSocket;
 };
 
 /**

--- a/tests/empathicVoice/chat.test.ts
+++ b/tests/empathicVoice/chat.test.ts
@@ -3,11 +3,15 @@ import { HumeClient } from "../../src/";
 describe("Empathic Voice Interface", () => {
     it.skip("Chat", async () => {
         const hume = new HumeClient({
-            apiKey: "<>",
-            secretKey: "<>",
+            accessToken: '<>'
         });
 
-        const socket = hume.empathicVoice.chat.connect();
+        const socket = hume.empathicVoice.chat.connect({
+            debug: true,
+            reconnectAttempts: 30,
+        });
+
+        await socket.tillSocketOpen();
 
         socket.on("message", (message) => {
             if (message.type === "audio_output") {
@@ -15,6 +19,8 @@ describe("Empathic Voice Interface", () => {
             }
         });
 
-        await socket.sendUserInput("Hello, how are you?");
+        socket.sendUserInput("Hello, how are you?");
+
+
     }, 100000);
 });


### PR DESCRIPTION
This PR exports an async helper `tillSocketOpen` so that consumers can wait to send messages till the socket is open.