### PR TITLE
fix: ws onclose handles 1000 status code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hume",
-    "version": "0.8.9",
+    "version": "0.8.10",
     "private": false,
     "repository": "https://github.com/HumeAI/hume-typescript-sdk",
     "main": "./index.js",

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -468,6 +468,10 @@ export class ReconnectingWebSocket {
         this._debug("close event");
         this._clearTimeouts();
 
+        if (event.code === 1000) {
+            this._shouldReconnect = false;
+        }
+
         if (this._shouldReconnect) {
             this._connect();
         }


### PR DESCRIPTION
Even though the `close` function handles shutting down with a 1000 status code, the `onclose` needs to handle this case as well. 