### PR TITLE
(feat): [types] require credentials when initializing HumeClient

### DIFF
--- a/src/wrapper/HumeClient.ts
+++ b/src/wrapper/HumeClient.ts
@@ -12,4 +12,10 @@ export class HumeClient extends FernClient {
     constructor(protected readonly _options: HumeClient.Options) {
         super(_options || {});
     }
+
+    protected _expressionMeasurement: ExpressionMeasurement | undefined;
+
+    public get expressionMeasurement(): ExpressionMeasurement {
+        return (this._expressionMeasurement ??= new ExpressionMeasurement(this._options));
+    }
 }

--- a/src/wrapper/HumeClient.ts
+++ b/src/wrapper/HumeClient.ts
@@ -2,13 +2,14 @@ import { HumeClient as FernClient } from "../Client";
 import { ExpressionMeasurement } from "./expressionMeasurement/ExpressionMeasurementClient";
 
 export declare namespace HumeClient {
-    export interface Options extends FernClient.Options {
-        secretKey?: string;
-    }
+    type Options = FernClient.Options & { secretKey?: string } & (
+            | { accessToken: FernClient.Options["accessToken"] }
+            | { apiKey: FernClient.Options["apiKey"] }
+        );
 }
 
 export class HumeClient extends FernClient {
-    constructor(protected readonly _options: HumeClient.Options = {}) {
+    constructor(protected readonly _options: HumeClient.Options) {
         super(_options);
     }
 }

--- a/src/wrapper/HumeClient.ts
+++ b/src/wrapper/HumeClient.ts
@@ -10,6 +10,6 @@ export declare namespace HumeClient {
 
 export class HumeClient extends FernClient {
     constructor(protected readonly _options: HumeClient.Options) {
-        super(_options);
+        super(_options || {});
     }
 }

--- a/src/wrapper/HumeClient.ts
+++ b/src/wrapper/HumeClient.ts
@@ -11,10 +11,4 @@ export class HumeClient extends FernClient {
     constructor(protected readonly _options: HumeClient.Options = {}) {
         super(_options);
     }
-
-    protected _expressionMeasurement: ExpressionMeasurement | undefined;
-
-    public get expressionMeasurement(): ExpressionMeasurement {
-        return (this._expressionMeasurement ??= new ExpressionMeasurement(this._options));
-    }
 }

--- a/src/wrapper/HumeClient.ts
+++ b/src/wrapper/HumeClient.ts
@@ -13,6 +13,8 @@ export class HumeClient extends FernClient {
         super(_options || {});
     }
 
+    // We need to override this from FernClient to use the extended
+    // `ExpressionMeasurement` from `wrapper` and not `api/resources/`
     protected _expressionMeasurement: ExpressionMeasurement | undefined;
 
     public get expressionMeasurement(): ExpressionMeasurement {

--- a/src/wrapper/HumeClient.ts
+++ b/src/wrapper/HumeClient.ts
@@ -3,8 +3,8 @@ import { ExpressionMeasurement } from "./expressionMeasurement/ExpressionMeasure
 
 export declare namespace HumeClient {
     type Options = FernClient.Options & { secretKey?: string } & (
-            | { accessToken: FernClient.Options["accessToken"] }
-            | { apiKey: FernClient.Options["apiKey"] }
+            | { accessToken: NonNullable<FernClient.Options["accessToken"]> }
+            | { apiKey: NonNullable<FernClient.Options["apiKey"]> }
         );
 }
 


### PR DESCRIPTION
Makes two changes to the HumeClient defined In `wrapper` (i.e. it's controlled manually, not fern-generated).

1. ~[Remove expressionMeasurement override](https://github.com/HumeAI/hume-typescript-sdk/commit/f8b61a26f06b0c485388f94093ea7c6ac78dee35) I removed the redefinition of `expressionMeasurement` and `_expressionMeasurement`. This is identical to what is in the parent FernClient class, so seemed needless to me.~ never mind, I was just confused.
2.  I redefined the `HumeClient.Options` type to *always* require either `apiKey` or `accessToken`. We want to prevent users from initializing the client without credentials because this will result in errors further downstream when they attempt to make requests / open connections.

Union of intersection can be confusing, I tested things out [here](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAygrmMAbAlhATgHgCoD4oC8U2UAPlABQUCUh+21A3AFDNTtQoB2wGAZgEMAxtABiGLgHkwwFAHsuAZygBvNhw0QuANxToFAWy3AA-AC4ocLgGsucgO5cWGjQLAoA0hBDnYCZGhYisDo3ADmZJZcACYQfNwQ0bjOLuzCIoqK2HLWWr7wiKgYmMGhXBHkVrHxXInJ6ql8EMBCABYYvla2Dk4NUAC+rBqgkFDSsgrKROLoUjLySlAAZKpQihBC6M1ePhal4QPLlCpQ6RCZ2blcFjNzE0oA2gDkZxc5Wk8AuofkJ26e3huEnGC0Uz3+Oy+AyYrGYQkmwCgcnmkwAjBYQZNCKpBvClIjkfdFAAmDEoxZEFTrTbbQFQABEfDkcnpuIRSPJigAzGSidiVK8su9rgymSy2fiOUSACy80H8iF0xnM1lw9mE0EAVjlWMpipAFhodFFKolwSloIAbDqKapBZctIbaAR8MrxWrJRrJgB2G1TO3uHYWN30gA0pyEGSFV2DACMBOhVXjzV6lAAOP0KwNKsVhtYbLbAIMM+OJs0EzkATkzeuzBpNLPD1MLxfppbz9uFcYEAC8k+rOaiAAw1gMA+sh8NaXT6LhGHiGrhwJBIU7KARcEDUcsWtHosacrPj4O58PAVooRQAfVyICv0Tk5yvdmAV4gAA9L8Bu2XWEA).