### PR TITLE
Add `verbose_transcription` query param to `/chat` endpoint

### DIFF
--- a/src/api/resources/empathicVoice/resources/chat/client/Client.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Client.ts
@@ -27,6 +27,9 @@ export declare namespace Chat {
         /** The ID of a chat group, used to resume a previous chat. */
         resumedChatGroupId?: string;
 
+        /** A flag to enable verbose transcription. Set this query parameter to `true` to have unfinalized user transcripts be sent to the client as interim UserMessage messages. The [interim](/reference/empathic-voice-interface-evi/chat/chat#receive.User%20Message.interim) field on a [UserMessage](/reference/empathic-voice-interface-evi/chat/chat#receive.User%20Message.type) denotes whether the message is "interim" or "final." */
+        verboseTranscription?: boolean
+
         /** Extra query parameters sent at WebSocket connection */
         queryParams?: Record<string, string | string[] | object | object[]>;
     }
@@ -54,6 +57,10 @@ export class Chat {
         }
         if (args.resumedChatGroupId != null) {
             queryParams["resumed_chat_group_id"] = args.resumedChatGroupId;
+        }
+
+        if (args.verboseTranscription != null) {
+            queryParams["verbose_transcription"] = args.verboseTranscription ? 'true' : 'false';
         }
 
         if (args.queryParams != null) {

--- a/src/api/resources/empathicVoice/resources/chat/client/Client.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Client.ts
@@ -28,7 +28,7 @@ export declare namespace Chat {
         resumedChatGroupId?: string;
 
         /** A flag to enable verbose transcription. Set this query parameter to `true` to have unfinalized user transcripts be sent to the client as interim UserMessage messages. The [interim](/reference/empathic-voice-interface-evi/chat/chat#receive.User%20Message.interim) field on a [UserMessage](/reference/empathic-voice-interface-evi/chat/chat#receive.User%20Message.type) denotes whether the message is "interim" or "final." */
-        verboseTranscription?: boolean
+        verboseTranscription?: boolean;
 
         /** Extra query parameters sent at WebSocket connection */
         queryParams?: Record<string, string | string[] | object | object[]>;
@@ -60,7 +60,7 @@ export class Chat {
         }
 
         if (args.verboseTranscription != null) {
-            queryParams["verbose_transcription"] = args.verboseTranscription ? 'true' : 'false';
+            queryParams["verbose_transcription"] = args.verboseTranscription ? "true" : "false";
         }
 
         if (args.queryParams != null) {


### PR DESCRIPTION
Turns out this file is manually maintained, so I had to add support for the query parameter manually.