### PR TITLE
Add custom voices

### DIFF
--- a/src/api/resources/empathicVoice/client/Client.ts
+++ b/src/api/resources/empathicVoice/client/Client.ts
@@ -6,6 +6,7 @@ import * as environments from "../../../../environments";
 import * as core from "../../../../core";
 import { Tools } from "../resources/tools/client/Client";
 import { Prompts } from "../resources/prompts/client/Client";
+import { CustomVoices } from "../resources/customVoices/client/Client";
 import { Configs } from "../resources/configs/client/Client";
 import { Chats } from "../resources/chats/client/Client";
 import { ChatGroups } from "../resources/chatGroups/client/Client";
@@ -42,6 +43,12 @@ export class EmpathicVoice {
 
     public get prompts(): Prompts {
         return (this._prompts ??= new Prompts(this._options));
+    }
+
+    protected _customVoices: CustomVoices | undefined;
+
+    public get customVoices(): CustomVoices {
+        return (this._customVoices ??= new CustomVoices(this._options));
     }
 
     protected _configs: Configs | undefined;


### PR DESCRIPTION
Turns out that `empathicVoice/client.ts` **isn't** actually auto-generated. (See https://github.com/HumeAI/hume-typescript-sdk/pull/248) "remove lies". We need to update it to add a reference to the CustomVoices client. fixes #247 