### PR TITLE
Make Content-Type optional in convertBase64ToBlob

### DIFF
--- a/src/wrapper/convertBase64ToBlob.ts
+++ b/src/wrapper/convertBase64ToBlob.ts
@@ -5,7 +5,7 @@
  * @param {string} contentType - The MIME type to assign to the resulting `Blob`.
  * @returns {Blob} A `Blob` object containing the binary data from the base64 string.
  */
-export function convertBase64ToBlob(base64: string, contentType: string): Blob {
+export function convertBase64ToBlob(base64: string, contentType?: string): Blob {
     // Decode base64 string to a binary string
     const binaryString = window.atob(base64);
 


### PR DESCRIPTION
This PR makes the `mimeType` parameter optional in `convertBase64ToBlob`.

EVI always returns audio in `audio/wav`, so it's a mistake to call `convertBase64ToBlob` with anything other than `audio/wav` (our example code / docs code contains mistakes). Although for most examples I think it is better to call it with **nothing**. There is no way (right now) to ask EVI what format to return, and labeling it is not actually necessary, so the application should just not express an opinion about what format the audio coming back from EVI is, it should just pass it to `HTMLAudioElement` for playback without labeling.
