### PR TITLE
Zg/resume on reconnect

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 
 import * as environments from "./environments";
 import * as core from "./core";

--- a/src/api/resources/empathicVoice/client/Client.ts
+++ b/src/api/resources/empathicVoice/client/Client.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 
 import * as environments from "../../../../environments";
 import * as core from "../../../../core";

--- a/src/api/resources/empathicVoice/resources/chat/client/Client.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Client.ts
@@ -102,8 +102,8 @@ export class Chat {
         if (!shouldResume) return true;
         // Allow attempt
         const resumableCloseCodes: Set<number> = new Set([1006, 1011, 1012, 1013, 1014]);
-        if (resumableCloseCodes.has(event.code)) return true; 
+        if (resumableCloseCodes.has(event.code)) return true;
         // Prevent attempt
-        return false; 
+        return false;
     }
 }

--- a/src/api/resources/empathicVoice/resources/chat/client/Client.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Client.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 import * as environments from "../../../../../../environments";
 import * as core from "../../../../../../core";
 import qs from "qs";

--- a/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 import * as core from "../../../../../../core";
 import * as errors from "../../../../../../errors";
 import * as Hume from "../../../../../index";

--- a/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
@@ -225,8 +225,8 @@ export class ChatSocket {
         });
         if (parsedResponse.ok) {
             const message = parsedResponse.value;
-            if (message.type === 'chat_metadata' && this._shouldResumeChat) {
-                this.socket.setQueryParamOverride('resumed_chat_group_id', message.chatGroupId);
+            if (message.type === "chat_metadata" && this._shouldResumeChat) {
+                this.socket.setQueryParamOverride("resumed_chat_group_id", message.chatGroupId);
             }
             this.eventHandlers.message?.({ ...message, receivedAt: new Date() });
         } else {

--- a/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
@@ -25,8 +25,6 @@ export class ChatSocket {
 
     protected readonly eventHandlers: ChatSocket.EventHandlers = {};
 
-    private _chatGroupId: string | null = null;
-
     private readonly _shouldResumeChat: boolean;
 
     constructor({ socket, shouldResumeChat }: ChatSocket.Args) {
@@ -228,16 +226,8 @@ export class ChatSocket {
         if (parsedResponse.ok) {
             const message = parsedResponse.value;
             if (message.type === 'chat_metadata' && this._shouldResumeChat) {
-                const { chatGroupId } = message;
-                this._chatGroupId = chatGroupId;
-
-                const urlToModify = new URL(this.socket.url);
-                urlToModify.searchParams.set('resumed_chat_group_id', this._chatGroupId);
-                const newUrlString = urlToModify.toString();
-
-                this.socket.updateUrlProvider(newUrlString);
+                this.socket.setQueryParamOverride('resumed_chat_group_id', message.chatGroupId);
             }
-
             this.eventHandlers.message?.({ ...message, receivedAt: new Date() });
         } else {
             this.eventHandlers.error?.(new Error(`Received unknown message type`));

--- a/src/api/resources/empathicVoice/resources/chat/client/index.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/index.ts
@@ -1,3 +1,3 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 export { ChatSocket } from "./Socket";
 export { Chat } from "./Client";

--- a/src/api/resources/empathicVoice/resources/chat/index.ts
+++ b/src/api/resources/empathicVoice/resources/chat/index.ts
@@ -1,3 +1,3 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 export * from "./types";
 export * from "./client";

--- a/src/core/fetcher/Supplier.ts
+++ b/src/core/fetcher/Supplier.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 export type Supplier<T> = T | (() => T);
 
 export const Supplier = {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 export * from "./streaming-fetcher";
 export * from "./fetcher";
 export * from "./runtime";

--- a/src/core/websocket/events.ts
+++ b/src/core/websocket/events.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 export class Event {
     public target: any;
     public type: string;

--- a/src/core/websocket/index.ts
+++ b/src/core/websocket/index.ts
@@ -1,2 +1,2 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 export * from "./ws";

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -75,9 +75,9 @@ export class ReconnectingWebSocket {
     private _binaryType: BinaryType = "blob";
     private _closeCalled = false;
     private _messageQueue: Message[] = [];
-    private _url: UrlProvider;
     private _queryParamOverrides = new Map<string, string>();
-
+    
+    private readonly _url: UrlProvider;
     private readonly _protocols?: string | string[];
     private readonly _options: Options;
 

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -76,7 +76,7 @@ export class ReconnectingWebSocket {
     private _closeCalled = false;
     private _messageQueue: Message[] = [];
     private _queryParamOverrides = new Map<string, string>();
-    
+
     private readonly _url: UrlProvider;
     private readonly _protocols?: string | string[];
     private readonly _options: Options;

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 import { RUNTIME } from "../runtime";
 import * as Events from "./events";
 import { WebSocket as NodeWebSocket } from "ws";

--- a/src/errors/HumeError.ts
+++ b/src/errors/HumeError.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 export class HumeError extends Error {
     readonly statusCode?: number;
     readonly body?: unknown;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 export * as Hume from "./api";
 export * from "./wrapper";
 export { HumeEnvironment } from "./environments";

--- a/tests/empathicVoice/chat.test.ts
+++ b/tests/empathicVoice/chat.test.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 import { HumeClient } from "../../src/";
 
 describe("Empathic Voice Interface", () => {

--- a/tests/expressionMeasurement/batch.test.ts
+++ b/tests/expressionMeasurement/batch.test.ts
@@ -1,4 +1,4 @@
-/** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+/** THIS FILE IS MANUALLY MAINTAINED: see .fernignore */
 import { HumeClient } from "../../src/";
 
 describe("Streaming Expression Measurement", () => {


### PR DESCRIPTION
## Summary of Changes Made

### EmpathicVoice Client
- Adds built-in support for resuming a Chats when reconnecting
    - Adds optional `shouldAttemptReconnect` callback argument in `ReconnectingWebSocket` for implementing custom logic for when to try to reconnect.
    - Add means for setting and deleting query params that are included in the url when the ReconnectingWebSocket connects for the purpose of adding the `resumed_chat_group_id` query param to the handshake url to support resume on reconnect.)
    - Update `ChatSocket` to extract `chatGroupId` from chat_metadata message and update query param overrides on `ReconnectingWebSocket` by default to support resume on reconnect.
    - Add optional `shouldResumeChat` option for `ChatClient` 
    - Update `Chat` client to accept optional `shouldResumeChat` argument (escape hatch for default resume on reconnect behavior)
    - Add static method on `Chat` client for reconnect logic, only attempting a reconnect when WebSocket was closed with one of the following [WebSocket close codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/code#value):
        - `1006` (Abnormal Closure)
        - `1011` (Internal Error)
        - `1012` (Service Restart)
        - `1013` (Try Again Later)
        - `1014` (Bad Gateway)