### PR TITLE
Update getAudioStream with an object for configuration

### DIFF
--- a/src/wrapper/getAudioStream.ts
+++ b/src/wrapper/getAudioStream.ts
@@ -1,3 +1,9 @@
+export type AudioStreamOptions = {
+    echoCancellation?: boolean;
+    noiseSuppression?: boolean;
+    autoGainControl?: boolean;
+};
+
 /**
  * Requests an audio stream from the user's device using the `getUserMedia` API.
  * The stream will have echo cancellation, noise suppression, and auto gain control enabled.
@@ -5,11 +11,8 @@
  * @returns {Promise<MediaStream>} A promise that resolves to a `MediaStream` containing audio data only.
  * @throws {DOMException} If the user denies access or no audio input devices are found.
  */
-export const getAudioStream = async (
-    echoCancellation: boolean = true,
-    noiseSuppression: boolean = true,
-    autoGainControl: boolean = true,
-): Promise<MediaStream> => {
+export const getAudioStream = async (audioStreamOptions: AudioStreamOptions = {}): Promise<MediaStream> => {
+    const { echoCancellation = true, noiseSuppression = true, autoGainControl = true } = audioStreamOptions;
     return navigator.mediaDevices.getUserMedia({
         audio: {
             echoCancellation,


### PR DESCRIPTION
Improving the interface of `getAudioStream` to use an object for configuration rather than optional params