### PR TITLE
Zg/fix rws error handler

### DIFF
--- a/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
@@ -234,12 +234,7 @@ export class ChatSocket {
     };
 
     private handleError = (event: core.ErrorEvent) => {
-        try {
-            const message = event.message ?? `core.ReconnectingWebSocket error (${JSON.stringify(event)})`;
-            this.eventHandlers.error?.(new Error(message));
-        } catch {
-            const message = event.message ?? `core.ReconnectingWebSocket error (unable to stringify)`;
-            this.eventHandlers.error?.(new Error(message));
-        }
+        // Create and dispatch a new Error object using the message from the standardized event.
+        this.eventHandlers.error?.(new Error(event.message));
     };
 }

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -356,7 +356,7 @@ export class ReconnectingWebSocket {
      * @param error - The specific Error instance indicating the reason for termination.
      * @param closeReason - The reason string to use for the final CloseEvent.
      */
-    private _terminateConnectionAttempt(error: Error, closeReason: string): void {
+    private _shutdown(error: Error, closeReason: string): void {
         this._debug("Terminating connection attempts. Reason:", error.message);
 
         // Ensure state prevents further attempts
@@ -393,7 +393,7 @@ export class ReconnectingWebSocket {
 
         // WebSocket implementation check
         if (!isWebSocket(WebSocket)) {
-            this._terminateConnectionAttempt(
+            this._shutdown(
                 new Error("No valid WebSocket implementation found or provided. Cannot connect."),
                 "Fatal: No WebSocket support",
             );
@@ -402,10 +402,7 @@ export class ReconnectingWebSocket {
 
         // Max retries check
         if (this._retryCount >= maxRetries) {
-            this._terminateConnectionAttempt(
-                new Error(`Max retries (${maxRetries}) reached. Giving up.`),
-                "Max retries reached",
-            );
+            this._shutdown(new Error(`Max retries (${maxRetries}) reached. Giving up.`), "Max retries reached");
             return;
         }
 

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -588,7 +588,7 @@ export class ReconnectingWebSocket {
             this._shouldReconnect = false;
             this._debug("Reconnection stopped: RWS.close() was called.");
         } else if (adaptedEvent.code === 1000) {
-            this.shouldReconnect = false;
+            this._shouldReconnect = false;
             this._debug("Reconnection stopped: Received close code 1000 (intentional server close).");
         }
 

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -584,12 +584,11 @@ export class ReconnectingWebSocket {
         this._connectLock = false;
 
         // Determine reconnection intent
-        let attemptReconnect = this._shouldReconnect;
         if (this._closeCalled) {
-            attemptReconnect = false;
+            this._shouldReconnect = false;
             this._debug("Reconnection stopped: RWS.close() was called.");
         } else if (adaptedEvent.code === 1000) {
-            attemptReconnect = false;
+            this.shouldReconnect = false;
             this._debug("Reconnection stopped: Received close code 1000 (intentional server close).");
         }
         this._shouldReconnect = attemptReconnect;

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -243,7 +243,7 @@ export class ReconnectingWebSocket {
         if (!this._ws || this._ws.readyState === this.CLOSED) {
             this._connect();
         } else {
-            // If the socket is already connected then disconnect. The socket will be reconnected in _handleClose
+            // If the socket is already connected then disconnect. The socket will conditionally reconnected in _handleClose
             this._disconnect(code, reason);
         }
     }

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -591,7 +591,6 @@ export class ReconnectingWebSocket {
             this.shouldReconnect = false;
             this._debug("Reconnection stopped: Received close code 1000 (intentional server close).");
         }
-        this._shouldReconnect = attemptReconnect;
 
         // Dispatch event to listeners
         if (this.onclose) this.onclose(adaptedEvent);

--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -85,6 +85,9 @@ export class ReconnectingWebSocket {
         this._url = url;
         this._protocols = protocols;
         this._options = options;
+        if (!isWebSocket(this._options.WebSocket)) {
+            throw Error("No valid WebSocket class provided");
+        }
         if (this._options.startClosed) {
             this._shouldReconnect = false;
         }
@@ -393,15 +396,6 @@ export class ReconnectingWebSocket {
             connectionTimeout = DEFAULT.connectionTimeout,
             WebSocket = getGlobalWebSocket(),
         } = this._options;
-
-        // WebSocket implementation check
-        if (!isWebSocket(WebSocket)) {
-            this._shutdown(
-                new Error("No valid WebSocket implementation found or provided. Cannot connect."),
-                "Fatal: No WebSocket support",
-            );
-            return;
-        }
 
         // Max retries check
         if (this._retryCount >= maxRetries) {


### PR DESCRIPTION
# Summary of Changes Made

**This PR refactors our `ReconnectingWebSocket` implementation to harden error handling and reconnection logic:**

- **Always use abnormal close on error:** introduce `ABNORMAL_CLOSURE_CODE = 1006` so any error path closes with code 1006, avoiding unintended “clean” closes that blocked retries.
- **Unified error adaptation:** add a new `_adaptError(raw)` helper to normalize any thrown value (Error, DOM event, existing `ErrorEvent`) into a consistent `Events.ErrorEvent`.
- **Centralized reconnect in close handler:** simplify `_handleError` to only tear down, and move all retry logic into `_handleClose`, ensuring a single reconnection path.
- **Guaranteed retry on initial failures:** if the URL provider or constructor throws before any socket exists, we now explicitly call `_connect()` once, restoring “retry even before first open.”
- **Promise‐chain `.catch()` in `_connect()`:** catch URL lookups or constructor throws and feed them into `_handleError` instead of letting them become unhandled rejections.
- **Clean “give up” termination:** in `_shutdown`, emit both an `error` **and** a final `close(1000)` event when max-retries are reached or no WebSocket is available.
- **Lock & state hygiene:** consistently reset `_connectLock`, clear timeouts, and null out `_ws` in `_handleClose` to prevent stale‐lock or ghost‐retry bugs.

## Error & Close Scenarios

### Error scenarios (all close with code 1006 → retry unless fatal)
1. **Invalid WebSocket implementation**  
   - _When:_ first `_connect()` sees no valid `WebSocket`  
   - _Emits:_ `ErrorEvent("No valid WebSocket…")`, `CloseEvent(1000,"Fatal: No WebSocket support")`  
   - _Reconnect:_ **No**  

2. **Max-retries exhausted**  
   - _When:_ `_retryCount >= maxRetries`  
   - _Emits:_ `ErrorEvent("Max retries reached…")`, `CloseEvent(1000,"Max retries reached")`  
   - _Reconnect:_ **No**  

3. **Connection timeout**  
   - _When:_ socket not open in `connectionTimeout` ms  
   - _Emits:_ `ErrorEvent("TIMEOUT")`, `CloseEvent(1006,"TIMEOUT")`  
   - _Reconnect:_ **Yes** (back-off + maxRetries)  

4. **URL/provider or constructor throw**  
   - _When:_ `urlProvider()` or `new WebSocket(...)` throws  
   - _Emits:_ `ErrorEvent(message)`, `CloseEvent(1006,message)`  
   - _Reconnect:_ **Yes** (initial failures now retry once)  

5. **Native WebSocket error event**  
   - _When:_ underlying socket emits `error`  
   - _Emits:_ `ErrorEvent(native)`, `CloseEvent(1006,…)`  
   - _Reconnect:_ **Yes**  

6. **Internal teardown exception**  
   - _When:_ `ws.close()` or `_handleClose` throws inside `_disconnect`  
   - _Emits:_ `ErrorEvent(teardown)`, `CloseEvent(1006,…)`  
   - _Reconnect:_ **Yes**  

### Close scenarios
1. **Client-initiated clean close**  
   - _When:_ `.close(1000)` called  
   - _Emits:_ `CloseEvent(1000, reason)`  
   - _Reconnect:_ **No**  

2. **Server-initiated normal close**  
   - _When:_ server sends code 1000 frame  
   - _Emits:_ `CloseEvent(1000, reason)`  
   - _Reconnect:_ **No**  

3. **Server-initiated abnormal close**  
   - _When:_ server closes with any code ≠ 1000  
   - _Emits:_ `CloseEvent(code ≠ 1000, reason)`  
   - _Reconnect:_ **Yes**  

4. **Error-driven synthetic close**  
   - _When:_ any error path invokes `_disconnect(1006)`  
   - _Emits:_ `CloseEvent(1006, message)`  
   - _Reconnect:_ **Yes**  

5. **Fatal termination**  
   - _When:_ no-WS or max-retries in `_shutdown`  
   - _Emits:_ `ErrorEvent(...)`, `CloseEvent(1000, reason)`  
   - _Reconnect:_ **No**  