### PR TITLE
resolve issue with protocol support in environment field

### DIFF
--- a/src/api/resources/empathicVoice/resources/chat/client/Client.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Client.ts
@@ -5,6 +5,16 @@ import qs from "qs";
 import { ChatSocket } from "./Socket";
 import { SDK_VERSION } from "../../../../../../version";
 
+export function createHostnameWithProtocol(environment: string) {
+    const protocol = /(https|http|wss|ws):\/\//.exec(environment);
+
+    if (protocol) {
+        return environment.replace("https://", "wss://").replace("http://", "ws://");
+    } else {
+        return `wss://${environment}`;
+    }
+}
+
 export declare namespace Chat {
     interface Options {
         environment?: core.Supplier<environments.HumeEnvironment | string>;
@@ -77,10 +87,11 @@ export class Chat {
             }
         }
 
-        const environ = (core.Supplier.get(this._options.environment) ?? environments.HumeEnvironment.Production)
-            .replace("https://", "wss://")
-            .replace("http://", "ws://");
-        const socket = new core.ReconnectingWebSocket(`${environ}/v0/evi/chat?${qs.stringify(queryParams)}`, [], {
+        const hostname = createHostnameWithProtocol(
+            core.Supplier.get(this._options.environment) ?? environments.HumeEnvironment.Production,
+        );
+
+        const socket = new core.ReconnectingWebSocket(`${hostname}/v0/evi/chat?${qs.stringify(queryParams)}`, [], {
             debug: args.debug ?? false,
             maxRetries: args.reconnectAttempts ?? 30,
         });

--- a/tests/empathicVoice/chat.test.ts
+++ b/tests/empathicVoice/chat.test.ts
@@ -1,4 +1,5 @@
 /** THIS FILE IS MANUALLY MAINAINED: see .fernignore */
+import { createHostnameWithProtocol } from "../../src/api/resources/empathicVoice/resources/chat/client/Client";
 import { HumeClient } from "../../src/";
 
 describe("Empathic Voice Interface", () => {
@@ -22,4 +23,14 @@ describe("Empathic Voice Interface", () => {
 
         socket.sendUserInput("Hello, how are you?");
     }, 100000);
+
+    it.each([
+        ["https://foo.bar", "wss://foo.bar"],
+        ["http://foo.bar", "ws://foo.bar"],
+        ["wss://foo.bar", "wss://foo.bar"],
+        ["ws://foo.bar", "ws://foo.bar"],
+        ["foo.bar", "wss://foo.bar"],
+    ])("Generates the correct hostname for %s", (input, expected) => {
+        expect(createHostnameWithProtocol(input)).toBe(expected);
+    });
 });


### PR DESCRIPTION
- prior to #360 `wss://` was always prefixed to the environment string. clients passing in values without a protocol no longer had a default `wss://` attached.
- this PR correctly attaches the corresponding protocol to various input conditions
- this PR also includes a test