### PR TITLE
don't throw error for unrecognized message type

### DIFF
--- a/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
+++ b/src/api/resources/empathicVoice/resources/chat/client/Socket.ts
@@ -224,8 +224,6 @@ export class ChatSocket {
                 ...parsedResponse.value,
                 receivedAt: new Date(),
             });
-        } else {
-            this.eventHandlers.error?.(new Error(`Received unknown message type`));
         }
     };
 


### PR DESCRIPTION
If an unknown (ie new) message type is received from assistant service, we should ignore it rather than triggering the websocket error handler. This allows for more flexibility to add new message types without breaking existing frontends. 