### PR TITLE
More universally supply accessToken

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -30,12 +30,19 @@ export declare namespace HumeClient {
     }
 }
 
-const fetcherThatAddsHeaders = (fetcherToWrap: core.FetchFunction): core.FetchFunction => {
+const customFetcher = (fetcherToWrap: core.FetchFunction, accessToken?: core.Supplier<string | undefined>): core.FetchFunction => {
     return (args: core.Fetcher.Args) => {
         const newArgs = { ...args };
         newArgs.headers = newArgs.headers ?? {};
         ((newArgs.headers["X-Hume-Client-Name"] = "typescript_sdk"),
             (newArgs.headers["X-Hume-Client-Version"] = SDK_VERSION));
+        if (accessToken) {
+            const supplied = core.Supplier.get(accessToken);
+            if (supplied) {
+                newArgs.headers = newArgs.headers ?? {};
+                newArgs.headers["Authorization"] = `Bearer ${supplied}`
+            }
+        }
         return fetcherToWrap(args);
     };
 };
@@ -47,7 +54,7 @@ export class HumeClient {
 
     constructor(protected readonly _options: HumeClient.Options = {}) {
         const defaultFetcher = _options.fetcher ?? core.fetcher;
-        this._options.fetcher = fetcherThatAddsHeaders(defaultFetcher);
+        this._options.fetcher = customFetcher(defaultFetcher, _options.accessToken);
     }
 
     public get tts(): Tts {


### PR DESCRIPTION
Right now we have manually overridden the EVI ChatClient to supply `accessToken` to the EVI websocket when connecting, but "accessToken" is NOT supplied when calling e.g. `hume.tts.synthesizeJson`.

This PR will make it so that when you do

`new HumeClient({accessToken: 'xyz'})` that **every API request** will send a header `Authorization: Bearer xyz`.

