### PR TITLE
No no-cache

### DIFF
--- a/src/wrapper/fetchAccessToken.ts
+++ b/src/wrapper/fetchAccessToken.ts
@@ -38,7 +38,6 @@ export const fetchAccessToken = async ({
         body: new URLSearchParams({
             grant_type: "client_credentials",
         }).toString(),
-        cache: "no-cache",
     });
     return z
         .object({


### PR DESCRIPTION
A user reports that setting the `cache-control` header is not supported in the cloudflare workers runtime.

I don't think we actually need to explicitly opt out of the cache in this helper. When I hit the oauth endpoint
```shell
$ curl https://api.hume.ai/oauth2-cc/token -d grant_type=client_credentials -H "Authorization: Basic $(echo -n "$HUME_API_KEY:$HUME_SECRET_KEY" | base64 -i -)" -i
HTTP/2 200
date: Thu, 16 Oct 2025 13:46:52 GMT
content-length: 165
apiproxy: oauth2-dispense-access-token r4
token: access_token=...
x-request-id: e77a3374-e47e-4ff3-b6ab-b7a178c66e28
via: 1.1 google
cf-cache-status: DYNAMIC
server: cloudflare
cf-ray: 98f8013edd9c9a85-MIA

{
  "token_type": "Bearer",
  "access_token": ...",
  "grant_type": "client_credentials",
  "issued_at": 1760622412,
  "expires_in": 1799
}
```
the `cf-cache-status: DYNAMIC` indicates that the access token is DYNAMIC i.e. not subject to caching, when no cache-control header is specified. Thus, it should be safe just to remove this.