### PR TITLE
Fix broken WS init

### DIFF
--- a/src/core/websocket/ws.ts
+++ b/src/core/websocket/ws.ts
@@ -77,7 +77,7 @@ function addApiKeyFromHeader({
     headers: Record<string, any> | undefined;
     queryParameters: Record<string, any> | undefined;
 }) {
-    const apiKeyValue = Object.entries(headers ?? {}).find(([k]) => k.toLowerCase() === 'x-hume-api-key')?.[1]
+    const apiKeyValue = Object.entries(headers ?? {}).find(([k]) => k.toLowerCase() === "x-hume-api-key")?.[1];
     if (apiKeyValue && !queryParameters?.["api_key"]) {
         return { ...queryParameters, api_key: apiKeyValue };
     }


### PR DESCRIPTION
1. Change `apiKey` to `api_key` in `addApiKeyFromHeader`